### PR TITLE
Improve mobile layout

### DIFF
--- a/css/site.css
+++ b/css/site.css
@@ -5,7 +5,8 @@ body {
 
 #header {
     color: white;
-    width: 800px;
+    max-width: 800px;
+    width: 100%;
     margin-top: 20px;
     margin-left: auto;
     margin-right: auto;
@@ -14,7 +15,8 @@ body {
 }
 
 #content {
-    width: 800px;
+    max-width: 800px;
+    width: 100%;
     margin-left: auto;
     margin-right: auto;
 }
@@ -238,7 +240,8 @@ body {
 #footer{
     color: white;
     text-align: right;
-    width: 800px;
+    max-width: 800px;
+    width: 100%;
     margin-left: auto;
     margin-right: auto;
     padding-right: 30px;
@@ -246,6 +249,23 @@ body {
 
 #PW {
     font-weight: bolder;
+}
+
+@media (max-width: 767px) {
+    #game,
+    #score {
+        height: auto;
+    }
+
+    #question {
+        height: auto;
+    }
+
+    #next_button {
+        position: static;
+        margin-top: 10px;
+        text-align: center;
+    }
 }
 
 .green {

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 
 <head>
     <meta http-equiv="content-type" content="text/html; charset=utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js"></script>
@@ -19,7 +20,7 @@
     <div id="header"><div class="glyphicon glyphicon-gift"></div> Urodzinowi milionerzy <div class="glyphicon glyphicon-gift"></div></div>
 
     <div id="content" class="row">
-        <div id="game" class="col-xs-8">
+        <div id="game" class="col-xs-12 col-sm-8">
             <div id="question" class="row">
                 <div id="question_number">
                     <div id="question_number_left"></div>
@@ -58,7 +59,7 @@
             </div>
         </div>
 
-        <div id="score" class="col-xs-4">
+        <div id="score" class="col-xs-12 col-sm-4">
             <div id="lifebelts">
                 <div id="lifebelts_left"></div>
                 <div id="lifebelts_center">
@@ -124,5 +125,4 @@
     <div id="footer">Programmed by <span id="PW">Paweł Wielga</span> &copy;</div>
 </body>
 
-</html>
 </html>


### PR DESCRIPTION
## Summary
- adjust layout widths to adapt to small screens
- use responsive columns for the game and score areas
- add viewport meta tag
- tweak layout for small screens with a media query
- remove duplicate html closing tag

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6844b4f79200832899fc89c7ba543239