### PR TITLE
Improve site CSS styling

### DIFF
--- a/css/site.css
+++ b/css/site.css
@@ -1,6 +1,10 @@
 body {
-    background-image: url("http://1.bp.blogspot.com/-p0s06MBIx_U/T8zKIBZ24pI/AAAAAAAAA7Y/n8hMZfpRic0/s1600/dark+blue+wallpaper+10.jpg");
+    background-image: linear-gradient(135deg, #0d1547 0%, #090F31 70%, #02040e 100%), url("http://1.bp.blogspot.com/-p0s06MBIx_U/T8zKIBZ24pI/AAAAAAA7Y/n8hMZfpRic0/s1600/dark+blue+wallpaper+10.jpg");
+    background-attachment: fixed;
+    background-size: cover;
     background-color: #c0caca;
+    font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+    color: #fff;
 }
 
 #header {
@@ -12,6 +16,7 @@ body {
     margin-right: auto;
     text-align: center;
     font-size: 40px;
+    text-shadow: 0 0 8px rgba(0, 0, 0, 0.6);
 }
 
 #content {
@@ -25,11 +30,15 @@ body {
 
 #game {
     height: 500px;
+    background-color: rgba(9, 15, 49, 0.8);
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.4);
 }
 
 #score {
     margin-top: 10px;
     height: 500px;
+    background-color: rgba(9, 15, 49, 0.8);
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.4);
 }
 
 #question {
@@ -46,15 +55,15 @@ body {
 }
 
 .answer:hover .answer_center {
-    background-color: #02040e;
+    background-color: #061b39;
 }
 
 .answer:hover .answer_left {
-    border-right:15px solid #02040e; 
+    border-right:15px solid #061b39;
 }
 
 .answer:hover .answer_right {
-    border-left: 15px solid #02040e;
+    border-left: 15px solid #061b39;
 }
 
 .answer_center {
@@ -67,24 +76,27 @@ body {
     height: 50px;
     float: left;
     background-color: #090F31;
+    transition: background-color 0.3s ease;
 }
 
 .answer_left {
-    width: 0; 
+    width: 0;
     height: 0;
     float: left;
     border-top: 25px solid transparent;
-    border-bottom: 25px solid transparent; 
-    border-right:15px solid #090F31; 
+    border-bottom: 25px solid transparent;
+    border-right:15px solid #090F31;
+    transition: border-color 0.3s ease;
 }
 
 .answer_right {
-    width: 0; 
-    height: 0; 
+    width: 0;
+    height: 0;
     float: left;
     border-top: 25px solid transparent;
     border-bottom: 25px solid transparent;
     border-left: 15px solid #090F31;
+    transition: border-color 0.3s ease;
 }
 
 .answers_horizontal_separator {
@@ -119,6 +131,7 @@ body {
     height: 70px;
     float: left;
     background-color: #090F31;
+    text-shadow: 0 0 6px rgba(0,0,0,0.5);
 }
 
 #question_text {
@@ -131,6 +144,7 @@ body {
     margin-right: 15px;
     padding: 20px;
     background-color: #090F31;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.4);
 }
 
 .lifebelt {
@@ -141,6 +155,7 @@ body {
     vertical-align: center;
     line-height: 70px;
     font-size: 20px;
+    transition: color 0.3s ease;
 }
 
 .lifebelt:hover {
@@ -174,6 +189,7 @@ body {
     height: 70px;
     float: left;
     background-color: #090F31;
+    box-shadow: 0 0 8px rgba(0, 0, 0, 0.5);
 }
 
 #points {
@@ -184,11 +200,13 @@ body {
     margin-right: 15px;
     padding-top: 10px;
     padding-left: 10px;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.4);
 }
 
 .points_step {
     height: 32px;
     padding-top: 8px;
+    transition: background-color 0.3s ease;
 }
 
 .point_symbol {
@@ -201,6 +219,7 @@ body {
     height: 16px;
     border: 3px solid;
     float: left;
+    transition: background-color 0.3s ease, border-color 0.3s ease;
 }
 
 .point_normal {
@@ -220,6 +239,7 @@ body {
     font-weight: bold;
     float: right;
     margin-right: 10px;
+    letter-spacing: 1px;
 }
 
 #next_button {
@@ -233,10 +253,12 @@ body {
     bottom: 140px;
     right: 35px;
     cursor: pointer;
+    transition: color 0.3s ease;
 }
 
 #next_button:hover {
     color: green;
+    text-decoration: underline;
 }
 
 #footer{
@@ -246,6 +268,7 @@ body {
     width: 100%;
     margin-left: auto;
     margin-right: auto;
+    margin-top: 40px;
     padding-right: 30px;
 }
 
@@ -272,6 +295,7 @@ body {
 
 .green {
     color: green;
+    font-weight: bold;
 }
 
 .noselect {

--- a/js/game.js
+++ b/js/game.js
@@ -189,8 +189,13 @@ function resetAnswersHTML() {
         .html("");
 };
 
+function disableAllAnswers() {
+    $(".answer_center").off("click").css("cursor","default");
+}
+
 function goodAnswer(answerBtn) {
     if (debug) { console.log("goodAnswer"); }
+    disableAllAnswers();
     setButtonColor(answerBtn,"goldenrod");
     setTimeout(function(){
         setButtonColor(answerBtn,"green");
@@ -211,6 +216,7 @@ function goodAnswer(answerBtn) {
 
 function wrongAnswer(answerBtn) {
     if (debug) { console.log("wrongAnswer"); }
+    disableAllAnswers();
     setButtonColor(answerBtn,"goldenrod");
     setTimeout(function(){
         setButtonColor(answerBtn,"red");


### PR DESCRIPTION
## Summary
- modernize styling with gradients, fonts and shadows
- smooth hover effects for answers and buttons
- highlight scoreboard and footer sections
- prevent selecting multiple answers by disabling other options once one is clicked

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6844b81fad008328a0bec06086a9770b