### PR TITLE
Improve answer selection behavior and visuals

### DIFF
--- a/css/site.css
+++ b/css/site.css
@@ -1,5 +1,5 @@
 body {
-    background-image: linear-gradient(135deg, #0d1547 0%, #090F31 70%, #02040e 100%), url("http://1.bp.blogspot.com/-p0s06MBIx_U/T8zKIBZ24pI/AAAAAAA7Y/n8hMZfpRic0/s1600/dark+blue+wallpaper+10.jpg");
+    background-image: linear-gradient(135deg, #13285b 0%, #0a1744 70%, #02010c 100%);
     background-attachment: fixed;
     background-size: cover;
     background-color: #c0caca;
@@ -306,4 +306,14 @@ body {
         -ms-user-select: none; /* Internet Explorer/Edge */
             user-select: none; /* Non-prefixed version, currently
                                   supported by Chrome and Opera */
+}
+
+@keyframes checkAnimation {
+    0% { transform: scale(1); }
+    50% { transform: scale(1.05); }
+    100% { transform: scale(1); }
+}
+
+.checking {
+    animation: checkAnimation 0.5s ease;
 }

--- a/js/game.js
+++ b/js/game.js
@@ -9,6 +9,8 @@ const answeredQuestionsIds = [];
 let questionsCount = 0;
 let actualQuestionId = 0;
 
+let answerLocked = false;
+
 let timeout = 2000;
 
 // Game code
@@ -124,6 +126,7 @@ function getNextQuestion(){
 };
 
 function showQuestOnScreen(questionId) {
+    answerLocked = false;
     const answersOrder = orderAnswers();
     const questionText = questions[questionId]["question"];
     const answerA =      questions[questionId]["answer_" + answersOrder[0]]
@@ -170,21 +173,29 @@ function resetAnswersHTML() {
     $("#answer_a").children(".answer_center")
         .removeClass("good_answer")
         .removeClass("wrong_answer")
+        .removeClass("checking")
+        .css("cursor","pointer")
         .unbind()
         .html("");
     $("#answer_b").children(".answer_center")
         .removeClass("good_answer")
         .removeClass("wrong_answer")
+        .removeClass("checking")
+        .css("cursor","pointer")
         .unbind()
         .html("");
     $("#answer_c").children(".answer_center")
         .removeClass("good_answer")
         .removeClass("wrong_answer")
+        .removeClass("checking")
+        .css("cursor","pointer")
         .unbind()
         .html("");
     $("#answer_d").children(".answer_center")
         .removeClass("good_answer")
         .removeClass("wrong_answer")
+        .removeClass("checking")
+        .css("cursor","pointer")
         .unbind()
         .html("");
 };
@@ -194,6 +205,9 @@ function disableAllAnswers() {
 }
 
 function goodAnswer(answerBtn) {
+    if(answerLocked) { return; }
+    answerLocked = true;
+    $(answerBtn).addClass("checking");
     if (debug) { console.log("goodAnswer"); }
     disableAllAnswers();
     setButtonColor(answerBtn,"goldenrod");
@@ -202,6 +216,7 @@ function goodAnswer(answerBtn) {
         checkScore();
         setTimeout(function(){
             question_number++;
+            $(answerBtn).removeClass("checking");
             resetButtonColor(answerBtn);
             if(question_number<13)
             {
@@ -215,6 +230,9 @@ function goodAnswer(answerBtn) {
 };
 
 function wrongAnswer(answerBtn) {
+    if(answerLocked) { return; }
+    answerLocked = true;
+    $(answerBtn).addClass("checking");
     if (debug) { console.log("wrongAnswer"); }
     disableAllAnswers();
     setButtonColor(answerBtn,"goldenrod");
@@ -222,6 +240,8 @@ function wrongAnswer(answerBtn) {
         setButtonColor(answerBtn,"red");
         setButtonColor($(".good_answer"),"green");
         setTimeout(function(){
+            $(answerBtn).removeClass("checking");
+            $(".good_answer").removeClass("checking");
             resetButtonColor(answerBtn);
             resetButtonColor($(".good_answer"));
             loseGame();


### PR DESCRIPTION
## Summary
- prevent clicking multiple answers at once by locking after a click
- reset the lock when a new question is shown
- update background to a blue gradient and add answer check animation
- animate selected answers while they are being validated

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6844bb6f552c8328bac20d5d80daec19