### PR TITLE
Fix blank screen after module split

### DIFF
--- a/js/questions.js
+++ b/js/questions.js
@@ -186,3 +186,5 @@ const questionsJSON = "{"+
                     "       }"+
                     "   ]"+
                     "}";
+
+window.questionsJSON = questionsJSON;

--- a/js/utils.js
+++ b/js/utils.js
@@ -26,3 +26,7 @@ function resetButtonColor(button) {
     $(button).parent().children(".answer_left").css("border-right-color","");
     $(button).parent().children(".answer_right").css("border-left-color","");
 }
+
+window.orderAnswers = orderAnswers;
+window.setButtonColor = setButtonColor;
+window.resetButtonColor = resetButtonColor;


### PR DESCRIPTION
## Summary
- expose helper functions and questions data via `window` so `game.js` can use them

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684524f9dae483289de9f5337beda7ae